### PR TITLE
Enabling `--inspect` debug mode for `npm run dev`

### DIFF
--- a/bin/irongenerate
+++ b/bin/irongenerate
@@ -129,8 +129,8 @@ function createApplication(app_name, path) {
     private: true,
     scripts: {
       'start': 'node ./bin/www',
-      'dev': `DEBUG=${app_name}:* nodemon ./bin/www`,
-      'dev-windows': `nodemon ./bin/www`,
+      'dev': `DEBUG=${app_name}:* nodemon --inspect ./bin/www`,
+      'dev-windows': `nodemon --inspect ./bin/www`,
     },
     dependencies: {
       'body-parser':   '^1.18.3',


### PR DESCRIPTION
In order students can easily debug their Node.js code, it could be handy enabling [`--inspect`](https://nodejs.org/api/debugger.html) mode by default when running `npm run dev` command.

I've also created a little tutorial about using debugger here: https://hackmd.io/s/H11KV60EV